### PR TITLE
Set AnimatedImageView to disable frame buffer to reduce memory footprint

### DIFF
--- a/Photo Editor/Photo Editor/ExpressionPreview.swift
+++ b/Photo Editor/Photo Editor/ExpressionPreview.swift
@@ -123,7 +123,7 @@ open class ExpressionPreview: UIView {
     func addGifObject (contentUrl: String, x: CGFloat, y: CGFloat, size: CGSize, transform: Transform) {
         let imageView: SDAnimatedImageView = SDAnimatedImageView()
         imageView.sd_setImage(with: URL(string: contentUrl))
-
+        imageView.maxBufferSize = 1
         imageView.contentMode = .scaleAspectFill
         imageView.frame.size = size
         imageView.center = CGPoint.init(x: x, y: y)

--- a/Photo Editor/Photo Editor/ExpressionScalablePreview.swift
+++ b/Photo Editor/Photo Editor/ExpressionScalablePreview.swift
@@ -137,6 +137,7 @@ open class ExpressionScalablePreview: UIView {
     
     func addGifObject (contentUrl: String, x: CGFloat, y: CGFloat, size: CGSize, transform: Transform) {
         let imageView: SDAnimatedImageView = SDAnimatedImageView()
+        imageView.maxBufferSize = 1
         imageView.sd_setImage(with: URL(string: contentUrl))
         imageView.contentMode = .scaleAspectFill
         imageView.frame.size = size

--- a/Photo Editor/Photo Editor/PhotoEditor+Export.swift
+++ b/Photo Editor/Photo Editor/PhotoEditor+Export.swift
@@ -330,7 +330,7 @@ extension PhotoEditorViewController {
     func addGifObject (contentUrl: String, x: CGFloat, y: CGFloat, size: CGSize, transform: Transform) {
         let imageView: SDAnimatedImageView = SDAnimatedImageView()
         imageView.sd_setImage(with: URL(string: contentUrl))
-        
+        imageView.maxBufferSize = 1
         imageView.contentMode = .scaleAspectFill
         imageView.frame.size = size
         imageView.center = CGPoint.init(x: x, y: y)

--- a/Photo Editor/Photo Editor/PhotoEditor+StickersViewController.swift
+++ b/Photo Editor/Photo Editor/PhotoEditor+StickersViewController.swift
@@ -58,6 +58,7 @@ extension PhotoEditorViewController: GifsStickersViewControllerDelegate {
             gifsSources[gifsSources.count - 1].url = gif
         } else {
             imageView = SDAnimatedImageView()
+            imageView?.maxBufferSize = 1
         }
         
         if let image = imageView {


### PR DESCRIPTION
This trades marginally more CPU for less memory usage. Overall I was able to stay under 1 GB of RAM used even when scrolling quite far in the list.